### PR TITLE
Add link buttons to help command

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from discord.ext import commands
 from strings import MESSAGES, VERSION
 from game_logic import Game, ActionContext
 from views.start_game_view import StartGameView
+from views.help_view import HelpView
 
 
 class Eggsplode(commands.Bot):  # pylint: disable=too-many-ancestors
@@ -208,7 +209,8 @@ async def show_help(ctx: discord.ApplicationContext):
             eggsplode_app.latency * 1000,
             VERSION,
             MESSAGES["maintenance"] if eggsplode_app.admin_maintenance else "",
-        )
+        ),
+        view=HelpView(),
     )
 
 

--- a/messages.json
+++ b/messages.json
@@ -5,7 +5,7 @@
   "before_attegg": "⚡ <@{}> wants to skip and force <@{}> to draw twice. Accept?",
   "before_skip": "⏩ <@{}> wants to skip their turn and not draw a card! Next up: <@{}>. Accept?",
   "before_steal": "{} <@{}> wants to steal a card from <@{}>! Accept?",
-  "bug_report_print": "===== Bug report from {} in channel {}: [{}] '{}'",
+  "bug_report_print": "BUG REPORT from {} in channel {}: [{}] '{}'",
   "bug_reported": "🐞 Bug reported! Thank you for your help!\nYou can also join our support server at https://discord.gg/UGm36FkGDF",
   "defuse_prompt": "🔧 You drew an **Eggsplode** card! Please decide where on the deck you want to put it.\n**Current position: {}**\n**Players:**\n{}",
   "defused": "## 🔧 <@{}> drew an Eggsplode card! Luckily, they had a Defuse and put it back into the deck!",
@@ -31,9 +31,6 @@
     "Some actions can be cancelled by clicking on **Nope**, if you have a **Nope** card. You can nope actions targeted at you or other players. Clicking on **Nope** on already cancelled actions will 'un-nope' (or 'yup') them.",
     "# Stealing",
     "If you have two food cards of the same type, you can steal a random card from another player of your choice.",
-    "# Still have questions?",
-    "You can ask for help or give feedback on our Discord server at https://discord.gg/UGm36FkGDF",
-    "If you experience any issue with the bot, please reach out by using the </bugreport:1333499107129561270> command.",
     "-# Ping: {:.0f}ms | Version: {} {}"
   ],
   "invalid_command": "❌ Invalid command.",

--- a/views/help_view.py
+++ b/views/help_view.py
@@ -1,0 +1,45 @@
+import discord
+
+
+class HelpView(discord.ui.View):
+    """
+    A view for the help command in the game.
+    """
+
+    def __init__(self):
+        """
+        Initializes the HelpView.
+        """
+        super().__init__(timeout=None)
+        self.add_item(
+            discord.ui.Button(
+                label="Website",
+                url="https://iqnite.github.io/eggsplode",
+                style=discord.ButtonStyle.link,
+                emoji="🌐",
+            )
+        )
+        self.add_item(
+            discord.ui.Button(
+                label="Support & Community server",
+                url="https://discord.gg/UGm36FkGDF",
+                style=discord.ButtonStyle.link,
+                emoji="💬",
+            )
+        )
+        self.add_item(
+            discord.ui.Button(
+                label="GitHub",
+                url="https://github.com/iqnite/eggsplode",
+                style=discord.ButtonStyle.link,
+                emoji="🐙",
+            )
+        )
+        self.add_item(
+            discord.ui.Button(
+                label="Invite to your server",
+                url="https://discord.com/oauth2/authorize?client_id=1325443178622484590",
+                style=discord.ButtonStyle.link,
+                emoji="🤖",
+            )
+        )

--- a/views/help_view.py
+++ b/views/help_view.py
@@ -1,3 +1,7 @@
+"""
+Contains the HelpView class for showing link buttons on the help command.
+"""
+
 import discord
 
 


### PR DESCRIPTION
Introduce a HelpView class to display link buttons for the website, support server, GitHub, and invite options in the help command. Update the help command to utilize this new view and enhance the documentation.