### PR TITLE
Improve game starting logic

### DIFF
--- a/eggsplode/cards/base.py
+++ b/eggsplode/cards/base.py
@@ -210,6 +210,21 @@ def deck_count(game: "Game") -> str:
     )
 
 
+def setup(game: "Game"):
+    for hand in game.hands.values():
+        hand.append("defuse")
+    game.deck += ["defuse"] * int(game.config.get("deck_defuse_cards", 0))
+    game.deck += ["eggsplode"] * max(
+        int(
+            game.config.get(
+                "deck_eggsplode_cards",
+                max(len(game.players) - 1, 2),
+            )
+        ),
+        len(game.players) - 1,
+    )
+
+
 PLAY_ACTIONS = {
     "attegg": attegg,
     "skip": skip,
@@ -226,4 +241,8 @@ DRAW_ACTIONS = {
 
 TURN_WARNINGS = [
     deck_count,
+]
+
+SETUP_ACTIONS = [
+    setup,
 ]

--- a/eggsplode/cards/radioeggtive.py
+++ b/eggsplode/cards/radioeggtive.py
@@ -182,6 +182,12 @@ async def radioeggtive_face_up(game: "Game", interaction: discord.Interaction, _
     await game.events.turn_end()
 
 
+def setup(game: "Game"):
+    game.deck += ["radioeggtive"] * (
+        "radioeggtive" in game.config.get("expansions", [])
+    )
+
+
 PLAY_ACTIONS = {
     "draw_from_bottom": draw_from_bottom,
     "targeted_attegg": targeted_attegg,
@@ -196,4 +202,8 @@ DRAW_ACTIONS = {
 
 TURN_WARNINGS = [
     radioeggtive_warning,
+]
+
+SETUP_ACTIONS = [
+    setup,
 ]

--- a/eggsplode/ui/start.py
+++ b/eggsplode/ui/start.py
@@ -192,7 +192,7 @@ class SettingsModal(discord.ui.Modal):
             "deck_eggsplode_cards": {
                 "input": discord.ui.InputText(
                     label="Eggsplode cards in deck",
-                    placeholder=str(len(self.game.config["players"]) - 1),
+                    placeholder=str(max(len(self.game.config["players"]) - 1, 2)),
                     value=self.game.config.get("deck_eggsplode_cards", None),
                     required=False,
                 ),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,49 @@
+"""
+Contains tests for the core module.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+from eggsplode.core import Game
+
+
+class TestGame(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "players": ["foo", "bar", "baz", "qux"],
+            "expansions": ["radioeggtive"],
+        }
+        self.game = Game(MagicMock(), self.config)
+
+    def test_setup(self):
+        self.game.setup()
+        for hand in self.game.hands.values():
+            self.assertEqual(hand.count("defuse"), 1)
+            self.assertEqual(len(hand), 8)
+        self.assertEqual(self.game.deck.count("eggsplode"), 3)
+        self.assertEqual(self.game.deck.count("radioeggtive"), 1)
+
+        self.game.config["expansions"].remove("radioeggtive")
+        self.game.setup()
+        self.assertEqual(self.game.deck.count("radioeggtive"), 0)
+
+        self.game.config["deck_eggsplode_cards"] = 2
+        self.game.setup()
+        self.assertEqual(self.game.deck.count("eggsplode"), 3)
+
+        self.game.config["deck_eggsplode_cards"] = 10
+        self.game.setup()
+        self.assertEqual(self.game.deck.count("eggsplode"), 10)
+
+        self.game.config["deck_defuse_cards"] = 2
+        self.game.setup()
+        self.assertEqual(self.game.deck.count("defuse"), 2)
+
+        self.game.config["players"] = ["foo", "bar"]
+        self.game.config["deck_eggsplode_cards"] = 1
+        self.game.setup()
+        self.assertEqual(self.game.deck.count("eggsplode"), 1)
+
+        del self.game.config["deck_eggsplode_cards"]
+        self.game.setup()
+        self.assertEqual(self.game.deck.count("eggsplode"), 2)


### PR DESCRIPTION
Resolves a suggestion by Psilo

- Re-added tests for game setup
- Added support for expansion-individual setup methods
- Changed default Eggsplode count for 2 players to 2
- Prevent players from setting an Eggsplode count lower than the # of players - 1