### PR TITLE
Show what a card does in Nope views

### DIFF
--- a/eggsplode/core.py
+++ b/eggsplode/core.py
@@ -241,6 +241,7 @@ class Game:
                     CARDS[card]["emoji"],
                     interaction.user.id,
                     CARDS[card]["title"],
+                    CARDS[card]["description"],
                 ),
             )
             await self.send(view=view)

--- a/resources/messages.json
+++ b/resources/messages.json
@@ -145,7 +145,7 @@
     "not_implemented": "🙁 Sorry, not implemented yet.",
     "not_your_turn": "❌ It's not your turn!",
     "page_count": "-# Page {} of {}",
-    "play_card": "{} <@{}> wants to **{}**!",
+    "play_card": "{} <@{}> wants to [**{}**](https://github.com/iqnite/eggsplode/wiki/Cards \"{}\")!",
     "play_prompt": "**Play** as many cards as you want, then **draw** a card to end your turn!",
     "play_prompt_radioeggtive": "☢️ Face up Radioeggtive comes in {} turns.",
     "play_prompt_radioeggtive_next": "☢️ Face up Radioeggtive comes in the next turn!",


### PR DESCRIPTION
Fixes #94

Hovering over a card's name in classic Nope views shows the description of that card.